### PR TITLE
Pin caddy-ratelimit to v0.1.0 for reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache gcc musl-dev
 RUN xcaddy build ${CADDY_VERSION} \
     --with github.com/lucaslorentz/caddy-docker-proxy/v2@v2.10.0 \
     --with github.com/greenpau/caddy-security@v1.1.31 \
-    --with github.com/mholt/caddy-ratelimit
+    --with github.com/mholt/caddy-ratelimit@v0.1.0
 
 FROM caddy:${CADDY_VERSION}-alpine
 


### PR DESCRIPTION
## Problem

The `Dockerfile`'s `xcaddy build` line included `caddy-ratelimit` **without a version pin**:

```dockerfile
RUN xcaddy build ${CADDY_VERSION} \
    --with github.com/lucaslorentz/caddy-docker-proxy/v2@v2.10.0 \   # pinned ✓
    --with github.com/greenpau/caddy-security@v1.1.31 \               # pinned ✓
    --with github.com/mholt/caddy-ratelimit                           # ← unpinned ✗
```

When a version is omitted, `xcaddy` uses the Go module proxy to resolve `@latest`, which means:

- **Non-reproducible builds**: Two builds at different times may produce different binaries
- **Silent upgrades**: A breaking API change or newly introduced vulnerability in a future version would be silently pulled in on the next `docker build`
- The other two plugins pin exact versions — this inconsistency looks unintentional

## Fix

Pin to `@v0.1.0`, the only current stable release of the plugin:

```dockerfile
    --with github.com/mholt/caddy-ratelimit@v0.1.0
```

## Testing

```bash
docker build -t caddy-home .
# Verify caddy validates and the rate_limit directive works
docker run --rm caddy-home caddy version
```

## Audit notes

| Area | Finding | Action |
|------|---------|--------|
| Dockerfile | Unpinned `caddy-ratelimit` xcaddy plugin | **Fixed (this PR)** |
| Caddyfile | `kavita` route has no `authorize with mypolicy` — unlike all other internal services | Likely intentional (Kavita has its own auth); worth confirming |
| Caddyfile | Secrets referenced via `{env.OAUTH_CLIENT_SECRET}`, `{env.JWT_SHARED_KEY}` etc. | Correct pattern — env var injection, no hardcoded secrets in this repo |
| caddy-security `v1.1.31` | Current pinned version; no known critical CVEs | No action needed this run |
