### PR TITLE
Add authorization to unauthenticated /kavita and /romm routes

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -131,6 +131,7 @@ newyork.welch.io {
 	}
 
 	route /kavita/* {
+		authorize with mypolicy
 		reverse_proxy rope.local:5000
 	}
 
@@ -142,6 +143,7 @@ newyork.welch.io {
 	}
 
 	route /romm/* {
+		authorize with mypolicy
 		encode zstd gzip
 
 		header * {


### PR DESCRIPTION
## Problem — Missing authorization on `/kavita/*` and `/romm/*` (HIGH severity)

Comparing the `Caddyfile` route-by-route, two internal services were missing the `authorize with mypolicy` directive that gates access through GitHub OAuth:

| Route | Auth before this PR |
|-------|---|
| `/kavita/*` | ❌ **No auth** — public |
| `/romm/*` | ❌ **No auth** — public |
| All other routes (radarr, sonarr, lidarr, sabnzbd, prowlarr, slskd, readarr, musicseerr, skyaware, files, archive) | ✅ `authorize with mypolicy` |

Anyone who can reach `newyork.welch.io` over the internet could access Kavita (personal library/e-book reader) and Romm (personal game ROM manager with IGDB credentials and auth secret key) without any authentication challenge.

Romm is particularly sensitive: it stores a `ROMM_AUTH_SECRET_KEY`, `IGDB_CLIENT_ID/SECRET`, and DB credentials in its configuration, and the web UI can manage file uploads.

## Root Cause

The `authorize with mypolicy` line was simply absent from these two `route` blocks. It is present on every other protected service.

## Fix

```diff
 route /kavita/* {
+    authorize with mypolicy
     reverse_proxy rope.local:5000
 }

 route /romm/* {
+    authorize with mypolicy
     encode zstd gzip
     ...
 }
```

## Testing

After deploying:
1. Open an incognito browser to `https://newyork.welch.io/kavita/` — should redirect to `/auth` (GitHub OAuth login).
2. Open an incognito browser to `https://newyork.welch.io/romm/` — should redirect to `/auth`.
3. After authenticating as `icco`, both should load normally.

```bash
# Pre-auth: expect redirect to /auth, not 200
curl -s -o /dev/null -w "%{http_code}" https://newyork.welch.io/kavita/
# Should be 302 (redirect to auth), not 200
```

## Audit Note

**Reviewed**: entire `Caddyfile`, `Dockerfile`  
**Found & fixed**: `/kavita/*` and `/romm/*` routes lacked `authorize with mypolicy` — unauthenticated access to internal services  
**Skipped / future run**: The `JWT_SHARED_KEY`, `OAUTH_CLIENT_ID`, and `OAUTH_CLIENT_SECRET` are passed as plain environment variables in the compose file. Consider moving to Docker secrets. The `caddy-security` plugin (`greenpau/caddy-security`) is pinned to `v1.1.31` — check whether newer versions include security patches.
