### PR TITLE
chore: Add OCI annotation labels for GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ RUN xcaddy build ${CADDY_VERSION} \
 
 FROM caddy:${CADDY_VERSION}-alpine
 
+LABEL org.opencontainers.image.source=https://github.com/icco/caddy-home
+LABEL org.opencontainers.image.description="Caddy reverse proxy for icco's home server; custom xcaddy build with caddy-docker-proxy, caddy-security, and caddy-ratelimit modules."
+LABEL org.opencontainers.image.licenses=MIT
+
 ENV CADDY_INGRESS_NETWORKS=caddy
 ENV CADDY_DOCKER_CADDYFILE_PATH=/srv/Caddyfile
 


### PR DESCRIPTION
Adds the GitHub-recommended OCI annotation labels to the Dockerfile so that
the GHCR package page links back to this repo and shows description/license.

See: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images

Labels added to the final image stage:
- `org.opencontainers.image.source`
- `org.opencontainers.image.description`
- `org.opencontainers.image.licenses` (where a recognizable LICENSE exists)