### PR TITLE
Expose the rope-hosted Grafana at /grafana

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -52,6 +52,7 @@
 					"Archive Team Warrior" /archive/ icon "las la-dragon"
 					"Files" /files/ icon "las la-sitemap"
 					"FlightAware" /skyaware/ icon "las la-plane-departure"
+					"Grafana" /grafana/ icon "las la-chart-line"
 					"Kavita" /kavita/ icon "las la-book"
 					"Lidarr" /lidarr/ icon "las la-headphones"
 					"Prowlarr" /prowlarr/ icon "las la-paw"
@@ -125,6 +126,11 @@ newyork.welch.io {
 
 	route /kavita/* {
 		reverse_proxy rope.local:5000
+	}
+
+	route /grafana/* {
+		authorize with mypolicy
+		reverse_proxy rope.local:3000
 	}
 
 	# TODO: This is broken


### PR DESCRIPTION
## Summary

Adds a `/grafana/*` route on `newyork.welch.io` that authorizes through the existing caddy-security `mypolicy` (GitHub OAuth via the portal) and reverse_proxies to `rope.local:3000`, where the new local Loki+Prometheus+Tempo+Grafana stack lives. Also adds a "Grafana" entry to the portal landing-page link list.

This pairs with [icco/icco.me#152](https://github.com/icco/icco.me/pull/152), which actually stands up the LGTM stack on rope and points every alloy agent at it. Together they replace our blocked Grafana Cloud setup.

Because the route lives on the same vhost as the auth portal, the portal cookie (scoped to `newyork.welch.io`) is automatically reused — no second sign-in step. Grafana itself is configured with `GF_SERVER_SERVE_FROM_SUB_PATH=true` and `GF_SERVER_ROOT_URL=https://newyork.welch.io/grafana/` so it generates correct internal links.