### PR TITLE
Inject X-WEBAUTH-* headers for Grafana auth proxy passthrough

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -74,6 +74,8 @@
 			allow roles authp/admin authp/user
 			validate bearer header
 			inject headers with claims
+			inject header "X-WEBAUTH-USER" from "sub"
+			inject header "X-WEBAUTH-EMAIL" from "email"
 		}
 	}
 }


### PR DESCRIPTION
Grafana at `newyork.welch.io/grafana/` is currently double-prompting — portal GitHub OAuth gets you through caddy, but Grafana then shows its own login form because it has no signal that the user is already authenticated.

This adds two `inject header` lines to `mypolicy` so every authorize'd route also forwards:

- `X-WEBAUTH-USER` ← JWT `sub` claim (e.g. `github.com/icco`)
- `X-WEBAUTH-EMAIL` ← JWT `email` claim

Grafana's `auth.proxy` setting (in the companion icco/icco.me PR) reads these to transparently sign the user in. The `*arr` services already on `mypolicy` don't read these headers, so this is a no-op for them.

