### PR TITLE
chore: upgrade Caddy to v2.11.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,5 @@
 version: 2
 updates:
-  # Caddy base image — picks up `ARG CADDY_VERSION=` and `FROM caddy:...`.
-  # NOTE: xcaddy plugin pins on the `xcaddy build` line (caddy-docker-proxy,
-  # caddy-security, caddy-ratelimit) are NOT a Dependabot-supported ecosystem
-  # because they live inline in a RUN command rather than a go.mod. Bump
-  # those manually when refreshing the base image, or migrate to Renovate
-  # if automation is required.
   - package-ecosystem: docker
     directory: /
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,26 @@
 version: 2
 updates:
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-    versioning-strategy: increase
-    open-pull-requests-limit: 10
+  # Caddy base image — picks up `ARG CADDY_VERSION=` and `FROM caddy:...`.
+  # NOTE: xcaddy plugin pins on the `xcaddy build` line (caddy-docker-proxy,
+  # caddy-security, caddy-ratelimit) are NOT a Dependabot-supported ecosystem
+  # because they live inline in a RUN command rather than a go.mod. Bump
+  # those manually when refreshing the base image, or migrate to Renovate
+  # if automation is required.
   - package-ecosystem: docker
     directory: /
-    open-pull-requests-limit: 10
     schedule:
       interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      docker:
+        patterns:
+          - "*"
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/Caddyfile
+++ b/Caddyfile
@@ -42,11 +42,6 @@
 				# static_asset "assets/images/favicon.png" "image/png" "/srv/assets/favicon.png"
 				static_asset "assets/images/logo.svg" "image/svg+xml" /srv/themes/logo.svg
 
-				disable settings sshkeys
-				disable settings gpgkeys
-				disable settings mfa
-				disable settings connected
-
 				# https://icons8.com/line-awesome
 				links {
 					"Archive Team Warrior" /archive/ icon "las la-dragon"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # https://github.com/caddyserver/caddy/releases
-ARG CADDY_VERSION=2.10.2
+ARG CADDY_VERSION=2.11.3
 FROM caddy:${CADDY_VERSION}-builder AS builder
 
 ENV GODEBUG=netdns=cgo

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,10 @@ COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 COPY ./Caddyfile /srv/Caddyfile
 COPY ./themes /srv/themes
 
-RUN caddy validate
+RUN OAUTH_CLIENT_ID=dummy \
+    OAUTH_CLIENT_SECRET=dummy \
+    OAUTH_AUTH_URL=https://example.com/auth \
+    JWT_SHARED_KEY=dummy \
+    caddy validate
 
 CMD ["caddy", "docker-proxy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN apk add --no-cache gcc musl-dev
 # https://github.com/greenpau/caddy-security/releases
 # https://github.com/mholt/caddy-ratelimit/releases
 RUN xcaddy build ${CADDY_VERSION} \
-    --with github.com/lucaslorentz/caddy-docker-proxy/v2@v2.10.0 \
-    --with github.com/greenpau/caddy-security@v1.1.31 \
+    --with github.com/lucaslorentz/caddy-docker-proxy/v2@v2.12.0 \
+    --with github.com/greenpau/caddy-security@v1.1.62 \
     --with github.com/mholt/caddy-ratelimit
 
 FROM caddy:${CADDY_VERSION}-alpine


### PR DESCRIPTION
## Summary
- Bump `CADDY_VERSION` 2.10.2 → 2.11.3
- Bump `caddy-docker-proxy` v2.10.0 → v2.12.0
- Bump `caddy-security` v1.1.31 → v1.1.62
- Drop removed `disable settings ...` UI subdirective from Caddyfile
- Clean up `dependabot.yml`: drop unused npm, group docker + actions